### PR TITLE
use global parameters to configure the plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Keywords, Unique Random Charset & Length
+# Keywords, Unique Random Charset & Length
 
 Plugin for YOURLS to create a random URL string, with a minumim length
 
-##Description
+## Description
 
 This is a fork of afahmiparidin's project at https://github.com/afahmiparidin/Hashids-Yourls. The changes were submitted to him as a full request, but never accepted.
 
@@ -14,7 +14,7 @@ Credit to all of them.
 
 Overrides default behavior allowing: a custom minimum link length and links are random. Does not use the sequential incrementing. The plugin generates unique keyword based on next_id. It does not mess with existing links or custom links, only new,unique and randomly generated links. Keyword minimum length and character set are user-controlled via the admin interface.
 
-##Customization
+## Customization
 You need to add two global parameters to your YOURLS configuration:
 
 * HASHID_SALT
@@ -22,11 +22,11 @@ You need to add two global parameters to your YOURLS configuration:
 * HASHID_MINLEN
   the minimum length of the generated URL element.
 
-##Installation
+## Installation
 
 * place the files in "plugins/Hashids-Yourls"
 * Go to the Plugins administration page ( eg http://sho.rt/admin/plugins.php ) and activate the plugin.
 * Change value of salt ($salt) and minimum character ($id) in /user/plugins/Hashids-Yourls/plugin.php
 
-##License
+## License
 YOURLS' license, aka "Do whatever the hell you want with it".

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keywords, Unique Random Charset & Length
 
-Plugin for YOURLS to create a random URL string, with a minumim length
+Plugin for YOURLS to create a random URL string, with a minimum length
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 #Keywords, Unique Random Charset & Length
 
-Plugin for YOURLS
+Plugin for YOURLS to create a random URL string, with a minumim length
 
 ##Description
+
+This is a fork of afahmiparidin's project at https://github.com/afahmiparidin/Hashids-Yourls. The changes were submitted to him as a full request, but never accepted.
+
+His original description:
 
 Based off ozh, peterberbec, giveforward and LudoBoggio's work. And not forget to ivanakimov, the writer of Hashids. 
 https://github.com/ivanakimov/hashids.php
@@ -10,11 +14,19 @@ Credit to all of them.
 
 Overrides default behavior allowing: a custom minimum link length and links are random. Does not use the sequential incrementing. The plugin generates unique keyword based on next_id. It does not mess with existing links or custom links, only new,unique and randomly generated links. Keyword minimum length and character set are user-controlled via the admin interface.
 
+##Customization
+You need to add two global parameters to your YOURLS configuration:
+
+* HASHID_SALT
+  a "hash value" individual to your installation. This should be a random string with at least 12 characters.
+* HASHID_MINLEN
+  the minimum length of the generated URL element.
+
 ##Installation
 
-1. In /user/plugins, create a new folder named key_char_len
-2. Drop these files in that directory.
-3. Go to the Plugins administration page ( eg http://sho.rt/admin/plugins.php ) and activate the plugin.
-4. Change value of salt ($salt) and minimum character ($id) in /user/plugins/Hashids-Yourls/plugin.php
+* place the files in "plugins/Hashids-Yourls"
+* Go to the Plugins administration page ( eg http://sho.rt/admin/plugins.php ) and activate the plugin.
+* Change value of salt ($salt) and minimum character ($id) in /user/plugins/Hashids-Yourls/plugin.php
 
-##License YOURLS' license, aka "Do whatever the hell you want with it".
+##License
+YOURLS' license, aka "Do whatever the hell you want with it".

--- a/plugin.php
+++ b/plugin.php
@@ -3,14 +3,25 @@
 Plugin Name: Hashids-Yourls
 Plugin URI: https://github.com/afahmiparidin/Hashids-Yourls/
 Description: To change different type of hashing keyword.
-Version: 0.1
+Version: 0.2
 Author: afahmiparidin
 Author URI: https://my.linkedin.com/in/fahmiparidin
+
+Modified by Jens-U. Mozdzen <jmozdzen@nde.ag>
+
+History:
+2022-10-21 JMo: we're now using HASHID_SALT and HASHID_MINLEN global parameters
+2022-10-21 JMo: cosmetic changes
 */
+
 require('lib/Hashids.php');
 
 // No direct call
 if( !defined( 'YOURLS_ABSPATH' ) ) die();
+
+// We use two global parameters
+if( !defined( 'HASHID_SALT' ) ) die();
+if( !defined( 'HASHID_MINLEN' ) ) die();
  
 // Generate a random keyword
 yourls_add_filter( 'random_keyword', 'afp_random_keyword' );
@@ -20,17 +31,17 @@ function afp_random_keyword() {
 	global $afp_random_keyword;
 
 	// Define Salt
-	$salt = 'DefineYourSaltHere'; // change your own salt
+	$salt = HASHID_SALT;
 
 	// Set minimum character of keyword
-	$minchar = 6; // default is 6
+	$minchar = HASHID_MINLEN;
 
 	// get next decimal from 
 	$id = yourls_get_next_decimal();
 	$possible = yourls_get_shorturl_charset() ;
 	$str='';
 
-	$hashids = new Hashids\Hashids($salt,$minchar); // Salt is qQZQlDX18C, min hash character is 6
+	$hashids = new Hashids\Hashids($salt,$minchar);
 	$str = $hashids->encode($id);
 
 	return $str;

--- a/plugin.php
+++ b/plugin.php
@@ -14,24 +14,25 @@ if( !defined( 'YOURLS_ABSPATH' ) ) die();
  
 // Generate a random keyword
 yourls_add_filter( 'random_keyword', 'afp_random_keyword' );
+
 function afp_random_keyword() {
-        // elaboration from ozh random-keywords-master plugin
-		global $afp_random_keyword;
-		
-		// Define Salt
-		$salt = 'DefineYourSaltHere'; // change your own salt
-		
-		// Set minimum character of keyword
-		$minchar = 6; // default is 6
-		
-		// get next decimal from 
-		$id = yourls_get_next_decimal();
-        $possible = yourls_get_shorturl_charset() ;
-        $str='';
-		
-		$hashids = new Hashids\Hashids($salt,$minchar); // Salt is qQZQlDX18C, min hash character is 6
-		$str = $hashids->encode($id);
-		
-        return $str;
+	// elaboration from ozh random-keywords-master plugin
+	global $afp_random_keyword;
+
+	// Define Salt
+	$salt = 'DefineYourSaltHere'; // change your own salt
+
+	// Set minimum character of keyword
+	$minchar = 6; // default is 6
+
+	// get next decimal from 
+	$id = yourls_get_next_decimal();
+	$possible = yourls_get_shorturl_charset() ;
+	$str='';
+
+	$hashids = new Hashids\Hashids($salt,$minchar); // Salt is qQZQlDX18C, min hash character is 6
+	$str = $hashids->encode($id);
+
+	return $str;
 }
 


### PR DESCRIPTION
Instead of having to change the source code, we can use the global parameters

HASHID_SALT
HASHID_MINLEN

to define the required configuration of the plug-in.

Additionally, some cosmetic clean-up was done (created consistent indent, removed trailing white space). 